### PR TITLE
Use window.localStorage to ensure the lib works in a mocha environment

### DIFF
--- a/src/persistState.js
+++ b/src/persistState.js
@@ -6,7 +6,7 @@ import adapter from './adapters/localStorage';
 const defaultKey = 'redux-localstorage';
 
 function getDefaultStorage() {
-  return adapter(localStorage);
+  return adapter(window.localStorage);
 }
 
 /**


### PR DESCRIPTION
Simple fix to ensure the library works when being run in a mocha environment which doesn't use `window` as the global variable