### PR TITLE
In persistStateMiddleware, return result action instead of input action

### DIFF
--- a/src/persistStateMiddleware.js
+++ b/src/persistStateMiddleware.js
@@ -8,12 +8,12 @@ export default function persistStateMiddleware(store, storage, key = 'redux-loca
   }
 
   return next => action => {
-    next(action);
+    const resultAction = next(action);
 
     if (action.type !== actionTypes.INIT) {
       persistState();
     }
 
-    return action;
+    return resultAction;
   };
 }


### PR DESCRIPTION
In order to make `dispatch` return the expected action, the persistStateMiddleware needs to return the result of `next(action)` rather than `action` itself.