### PR TITLE
Modified the 'usage' of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ npm install --save redux-localstorage
 import {compose, createStore} from 'redux';
 import persistState from 'redux-localstorage'
 
-const createPersistentStore = compose(
-  persistState(/*paths, config*/)
-)(createStore)
+const enhancer = compose(
+  /* [middlewares] */,
+  persistState(/*paths, config*/),
+)
 
-const store = createPersistentStore(/*reducer, initialState*/)
+const store = createStore(/*reducer, [initialState]*/, enhancer)
 ```
 
 ### persistState(paths, config)


### PR DESCRIPTION
I think the usage of enhancer on the docs are not longer the API the recommended in the Redux docs so I modified the README. 

Source : https://github.com/reactjs/redux/pull/1294