### PR TITLE
Adds .babelrc to .npmignore - babel 5 setting causes error in react-n…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 src
 .idea
+.babelrc


### PR DESCRIPTION
…ative