### PR TITLE
Fixed incorrect slicing when slice is 0 or null

### DIFF
--- a/src/getSubset.js
+++ b/src/getSubset.js
@@ -13,7 +13,7 @@ export default function getSubset(obj, paths) {
 
   paths.forEach((key) => {
     let slice = obj[key]
-    if (slice) subset[key] = slice
+    if (slice!==undefined) subset[key] = slice
   })
 
   return subset


### PR DESCRIPTION
It's currently not possibly to save a path with the value `0` or `null` because the if returns `false` when `obj[key]` is `0` or `null`. Caused me a lot of headache.

I saw you're already working on v1.0, but I hope you're releasing this a bugfix for the current version. It's causing a lot of trouble in my application.

Thanks!