### PR TITLE
Do not disable buffer until all queued actions dispatched

### DIFF
--- a/src/bufferActions.js
+++ b/src/bufferActions.js
@@ -13,12 +13,12 @@ export default function bufferActions(type = actionTypes.INIT) {
     if (!buffer) return next(action);
 
     if (action.type === type) {
-      buffer = false;
       next(action);
-      queue.forEach(queuedAction => {
-        next(queuedAction);
-      });
+      while (queue.length) {
+        next(queue.shift());
+      }
       queue = null;
+      buffer = false;
     } else {
       queue.push(action);
     }


### PR DESCRIPTION
This PR alters `bufferActions.js` to not disable the buffer until all actions in the queue are dispatched.

The issue I had was that whilst the buffer was being purged, the dispatched actions in the queue were causing other actions to be dispatched by other parts of the code (like in `componentDidMount`). Since `buffer = false` had already been set, these actions passed through the `bufferActions` middleware and got dispatched and reduced before the buffer had finished emptying - causing them to be incorrectly ordered.

resolves #67