### PR TITLE
Don't process if localStorage is nonexistent (f.e. server-side)

### DIFF
--- a/src/persistState.js
+++ b/src/persistState.js
@@ -36,6 +36,11 @@ export default function persistState(paths, config) {
   } = cfg
 
   return next => (reducer, initialState, enhancer) => {
+    
+    if (typeof localStorage === 'undefined') {
+      return next(reducer, initialState, enhancer)
+    }
+    
     if (typeof initialState === 'function' && typeof enhancer === 'undefined') {
       enhancer = initialState
       initialState = undefined


### PR DESCRIPTION
Small fix for current stable version. It stops lib from processing and showing warning if localStorage is not available. Useful in case of server-side rendered apps.