### PR TITLE
Adapter for using `chrome.storage.local` and `chrome.storage.sync`

### DIFF
--- a/src/adapters/storageArea/adapter.js
+++ b/src/adapters/storageArea/adapter.js
@@ -1,0 +1,19 @@
+export default (storage) => ({
+  0: storage,
+
+  put(key, value, callback) {
+    storage.set({ [key]: value }, callback)
+  },
+
+  get(key, callback) {
+    try {
+      storage.get(key, (items) => { callback(null, items[key]) })
+    } catch (e) {
+      callback(e)
+    }
+  },
+
+  del(key, callback) {
+    storage.remove(key, callback)
+  },
+})

--- a/src/adapters/storageArea/index.js
+++ b/src/adapters/storageArea/index.js
@@ -1,0 +1,1 @@
+export { default } from './adapter.js'


### PR DESCRIPTION
Adapter for using `chrome.storage.local` and `chrome.storage.sync` in chrome extension environments.

Also see [`dennisli92/Chrome-StorageArea-Adapter`](https://github.com/dennisli92/Chrome-StorageArea-Adapter)